### PR TITLE
5-targets Update T30_Warlock_Demonology.simc

### DIFF
--- a/fallback_profiles/castingpatchwerk5/Tier30/T30_Warlock_Demonology.simc
+++ b/fallback_profiles/castingpatchwerk5/Tier30/T30_Warlock_Demonology.simc
@@ -4,7 +4,7 @@ level=70
 race=troll
 role=spell
 position=ranged_back
-talents=BoQAAAAAAAAAAAAAAAAAAAAAAgcASSkkAplyBQaSSQJAAAAAoEBJkoFJRiEplWSkDQAAAAAAQC
+talents=BoQAAAAAAAAAAAAAAAAAAAAAAAIJRSCkWKHQkmkESJAAAAAoEBJSyBaRESiEplEJEAAAAAAkA
 
 head=cragshapers_fitted_hood,id=137341,bonus_id=8780,ilevel=447,gem_id=192985
 neck=magmoraxs_fourth_collar,id=204397,bonus_id=8782,ilevel=447,gem_id=192945/192945/192945


### PR DESCRIPTION
Update on the 5-targets fallback profile for Demonology

https://www.wowhead.com/ptr-2/talent-calc/warlock/demonology/DAORKERVARVWgUiBQCRAOVUVEUFRSIFAlhQBR 

Change is to account the changes in the talent structure of Demonology for 10.1.5 and improvements towards resource generation in a world without a 3rd Dreadstalkers.