### PR TITLE
S4 Talents Talents for Destruction

### DIFF
--- a/bloodytools/simulations/talent_tree_paths/warlock_destruction.yaml
+++ b/bloodytools/simulations/talent_tree_paths/warlock_destruction.yaml
@@ -1,2 +1,11 @@
-Generalistic M+:
-  - talents=BsQAAAAAAAAAAAAAAAAAAAAAAgESSkkAppApdgkESBk4AtkEJlgSpIJAAAAAAAAAAAACokkkA
+GWD  + Chaos Incarnate:
+  - talents=BsQAAAAAAAAAAAAAAAAAAAAAAAIJRSCRaKEpdgkESJaJQJJRUSoUKSCAAAAAAAAAAAAgSSSC
+
+Infernal + Chaos Incarnate + Avatar of Destruction: 
+  - talents=BsQAAAAAAAAAAAAAAAAAAAAAAAIJRSCRaKEpdgkESJIJSJSElEKlyBSCAAAAAAAAAAAAASSC
+
+Embers + Chaos Incarnate + Avatar of Destruction: 
+  - talents=BsQAAAAAAAAAAAAAAAAAAAAAAAIJRSCRaKEpdgkESJIJSJJRUSoUKHIAAAAAAAAAAAAAokkkA
+
+Chaos Incarnate + Avatar of Destruction + Crashing Chaos:
+  - talents=BsQAAAAAAAAAAAAAAAAAAAAAAAIJRSCRaKEpdgkESJcgkQJJRUSoUKkAAAAAAAAAAAAAokkkA


### PR DESCRIPTION
Demonology and Affliction need changes in regards to talents for S4.

Destruction on the other hand is changing talents, so 4 different profiles for Talents. 

2 more focused around AOE and 2 more around Single Target in M+.


OBS: Those Talents do not take the current S3 Tierset tied talent, so they might be losses with the T31 profile instead of the DF4 Destruction Warlock profile that will come with S4. 