### PR TITLE
Update Dockerfile to install dev dependencies list instead of dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apk --no-cache add --virtual build_dependencies \
     apk add --no-cache python3 py3-pip && \
     python3 -m venv /app/.venv && \
     . /app/.venv/bin/activate && \
-    pip3 install --no-cache-dir -r /app/bloodytools/requirements.txt
+    pip3 install --no-cache-dir -r /app/bloodytools/requirements-dev.txt
 
 # Enable python venv in entrypoint
 ENV PATH="/app/.venv/bin:$PATH"


### PR DESCRIPTION
`setuptools` has to be installed inside the image for `pkg_resources` to be available. I dunno why this wasn't already required - it's possible on older image versions something else was including setuptools in the environment already.